### PR TITLE
hotfix: medicine card text overflow

### DIFF
--- a/components/sections/pharmacies-medicines/children/medication-card.tsx
+++ b/components/sections/pharmacies-medicines/children/medication-card.tsx
@@ -93,7 +93,6 @@ const InfoWrap = styled("div")(({ theme }) => ({
 }));
 
 const GreyText = styled("div")(({ theme }) => ({
-  width: "max-content",
   fontSize: theme.fontSize.fontS16,
   color: theme.colors.grey,
 }));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/75245a44-6744-4da5-bc37-ae23087da733)
